### PR TITLE
Fix calling convention for express-sslify

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -82,7 +82,9 @@ var app = function(options) {
 
   // ForceSSL if required suggested
   if (options.forceSSL) {
-    app.use(sslify.HTTPS(options.trustProxy));
+    app.use(sslify.HTTPS({
+      trustProtoHeader: options.trustProxy,
+    }));
   }
 
   // When we force SSL, we also want to set the HSTS header file correctly.  We


### PR DESCRIPTION
In 1.0.0, sslify started requiring options, and basically did nothing
but log a warning if passed a boolean.