### PR TITLE
Bug 1412005: add robots.txt and sitemap.xml

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -61,6 +61,7 @@ var createServer = function() {
  *   forceSSL:              false,          // Force redirect to SSL or return 403
  *   trustProxy:            false,          // Trust the proxy that forwarded for SSL
  *   contentSecurityPolicy: true,           // Send CSP (default true!)
+ *   robotsTxt:             true,           // Serve a disallow-all robots.txt
  * }
  *
  * Returns an express application with extra methods:
@@ -70,6 +71,7 @@ var app = function(options) {
   assert(options,                           'options are required');
   _.defaults(options, {
     contentSecurityPolicy: true,
+    robotsTxt: true,
   });
   assert(typeof options.port === 'number', 'Port must be a number');
   assert(options.env == 'development' ||
@@ -121,6 +123,13 @@ var app = function(options) {
   // Middleware for development
   if (app.get('env') == 'development') {
     app.use(morganDebug('base:app:request', 'dev'));
+  }
+
+  if (options.robotsTxt) {
+    app.use('/robots.txt', function(req, res) {
+      res.header('Content-Type', 'text/plain');
+      res.send('User-Agent: *\nDisallow: /\n');
+    });
   }
 
   // Add some auxiliary methods to the app

--- a/test/app_test.js
+++ b/test/app_test.js
@@ -39,6 +39,13 @@ suite('app', function() {
       assert.equal(res.headers['strict-transport-security'], 'max-age=7776000000; includeSubDomains');
     });
 
+    test('/robots.txt', async function() {
+      var res = await request.get('http://localhost:1459/robots.txt');
+      assert(res.ok, 'Got response');
+      assert.equal(res.text, 'User-Agent: *\nDisallow: /\n', 'Got the right text');
+      assert.equal(res.headers['content-type'], 'text/plain; charset=utf-8');
+    });
+
     suiteTeardown(function() {
       return server.terminate();
     });

--- a/test/app_test.js
+++ b/test/app_test.js
@@ -5,29 +5,43 @@ suite('app', function() {
   var request = require('superagent');
 
   // Test app creation
-  test('app({port: 1459})', async function() {
-    // Create a simple app
-    var app = subject({
-      port:       1459,
-      env:        'development',
-      forceSSL:   false,
-      forceHSTS:  true,
-      trustProxy: false,
-    });
-    assert(app, 'Should have an app');
+  suite('app({port: 1459})', function() {
+    var server;
 
-    // Add an end-point
-    app.get('/test', function(req, res) {
-      res.status(200).send('Okay this works');
+    suiteSetup(async function() {
+      // Create a simple app
+      var app = subject({
+        port:       1459,
+        env:        'development',
+        forceSSL:   false,
+        forceHSTS:  true,
+        trustProxy: false,
+      });
+      assert(app, 'Should have an app');
+
+      // Add an end-point
+      app.get('/test', function(req, res) {
+        res.status(200).send('Okay this works');
+      });
+
+      // Create server
+      server = await app.createServer();
     });
 
-    // Create server
-    var server = await app.createServer();
-    var res = await request.get('http://localhost:1459/test');
-    assert(res.ok, 'Got response');
-    assert.equal(res.text, 'Okay this works', 'Got the right text');
-    assert.equal(res.headers['strict-transport-security'], 'max-age=7776000000; includeSubDomains');
-    return server.terminate();
+    test('get /test', async function() {
+      var res = await request.get('http://localhost:1459/test');
+      assert(res.ok, 'Got response');
+      assert.equal(res.text, 'Okay this works', 'Got the right text');
+    });
+
+    test('hsts header', async function() {
+      var res = await request.get('http://localhost:1459/test');
+      assert.equal(res.headers['strict-transport-security'], 'max-age=7776000000; includeSubDomains');
+    });
+
+    suiteTeardown(function() {
+      return server.terminate();
+    });
   });
 });
 


### PR DESCRIPTION
The robots.txt bit is pretty obvious here, but I'm less confident about the sitemap.  My reason to add it is, ZAP wants me to, but we could also ask that Simon configure ZAP not to scan this for APIs.

I'm not sure what URL we would expose for a sitemap..