### PR TITLE
Updated app.js for bug 1237575

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -78,8 +78,7 @@ var app = function(options) {
          options.env == 'production',       'env must be production or development');
   assert(options.forceSSL !== undefined,    'forceSSL must be defined');
   assert(options.trustProxy !== undefined,  'trustProxy must be defined');
-  assert(options.docs, 'options.docs must be given')
-
+  assert(options.docs, 'options.docs must be given');
 
   // Create application
   var app = express();
@@ -140,8 +139,8 @@ var app = function(options) {
 
   if (options.rootDocsRedirect) {
     let link = options.docs.documenter.getDocumentationUrl();
-    DOCS_HTML = "<html><body><a href="+link+">Refer to the documentation</a></body></html>"
-    app.get('/',function(req,res){
+    DOCS_HTML = "<html><body><a href="+link+">Refer to the documentation</a></body></html>";
+    app.get('/', function(req, res) {
       res.send(DOCS_HTML);
     });
   }

--- a/src/app.js
+++ b/src/app.js
@@ -78,6 +78,8 @@ var app = function(options) {
          options.env == 'production',       'env must be production or development');
   assert(options.forceSSL !== undefined,    'forceSSL must be defined');
   assert(options.trustProxy !== undefined,  'trustProxy must be defined');
+  assert(options.docs, 'options.docs must be given')
+
 
   // Create application
   var app = express();
@@ -129,6 +131,18 @@ var app = function(options) {
     app.use('/robots.txt', function(req, res) {
       res.header('Content-Type', 'text/plain');
       res.send('User-Agent: *\nDisallow: /\n');
+    });
+  }
+
+  if (options.docs == undefined) {
+    options.rootDocsRedirect = false;
+  }
+
+  if (options.rootDocsRedirect) {
+    let link = options.docs.documenter.getDocumentationUrl();
+    DOCS_HTML = "<html><body><a href="+link+">Refer to the documentation</a></body></html>"
+    app.get('/',function(req,res){
+      res.send(DOCS_HTML);
     });
   }
 


### PR DESCRIPTION
Added two new options 'docs' and 'rootDocsRedirect' . If rootDocsRedirect is true, then a static HTML containing the link to the documentation is rendered.