### PR TITLE
Add a link to the documentation to `/`

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -136,7 +136,7 @@ var app = function(options) {
   if (options.rootDocsRedirect) {
     let link = options.docs.documenter.getDocumentationUrl();
     DOCS_HTML = `<html><body><p>You're lost, here's the way out.</p>
-    <a href= ${link} >Refer to the documentation</a></body></html>`;
+    <a href= "${link}" >Refer to the documentation</a></body></html>`;
     app.get('/', function(req, res) {
       res.status(404).send(DOCS_HTML);
     });

--- a/src/app.js
+++ b/src/app.js
@@ -135,7 +135,8 @@ var app = function(options) {
 
   if (options.rootDocsRedirect) {
     let link = options.docs.documenter.getDocumentationUrl();
-    DOCS_HTML = `<html><body><p>You're lost, here's the way out.</p><a href= ${link} >Refer to the documentation</a></body></html>`;
+    DOCS_HTML = `<html><body><p>You're lost, here's the way out.</p>
+    <a href= ${link} >Refer to the documentation</a></body></html>`;
     app.get('/', function(req, res) {
       res.status(404).send(DOCS_HTML);
     });

--- a/src/app.js
+++ b/src/app.js
@@ -62,7 +62,7 @@ var createServer = function() {
  *   trustProxy:            false,          // Trust the proxy that forwarded for SSL
  *   contentSecurityPolicy: true,           // Send CSP (default true!)
  *   robotsTxt:             true,           // Serve a disallow-all robots.txt
- *   rootDocRedirect:       true,           // Indicator to redirect to a HTML with documentation link (default true!)
+ *   rootDocsLink:          true,           // Indicator to redirect to a HTML with documentation link (default true!)
  *   docs:                  'docs',         // Instance of taskcluster-lib-docs for accessing its methods
  * }
  *
@@ -74,14 +74,14 @@ var app = function(options) {
   _.defaults(options, {
     contentSecurityPolicy: true,
     robotsTxt: true,
-    rootDocsRedirect: true,
+    rootDocsLink: true,
   });
   assert(typeof options.port === 'number', 'Port must be a number');
   assert(options.env == 'development' ||
          options.env == 'production',       'env must be production or development');
   assert(options.forceSSL !== undefined,    'forceSSL must be defined');
   assert(options.trustProxy !== undefined,  'trustProxy must be defined');
-  assert(!options.rootDocsRedirect || options.docs, 'options.docs must be given if rootDocsRedirect is specified');
+  assert(!options.rootDocsLink || options.docs, 'options.docs must be given if rootDocsLink is specified');
 
   // Create application
   var app = express();
@@ -136,11 +136,11 @@ var app = function(options) {
     });
   }
 
-  // If rootDocsRedirect == true ,
+  // If rootDocsLink == true ,
   // we redirect to a HTML page with documentation link
-  if (options.rootDocsRedirect) {
-    let link = options.docs.documenter.getDocumentationUrl();
-    DOCS_HTML = `<html><body><p>You're lost, here's the way out.</p>
+  if (options.rootDocsLink) {
+    let link = options.docs.documentationUrl;
+    let DOCS_HTML = `<html><body><p>You're lost, here's the way out.</p>
     <a href= "${link}" >Refer to the documentation</a></body></html>`;
     app.get('/', function(req, res) {
       res.status(404).send(DOCS_HTML);

--- a/src/app.js
+++ b/src/app.js
@@ -78,8 +78,7 @@ var app = function(options) {
          options.env == 'production',       'env must be production or development');
   assert(options.forceSSL !== undefined,    'forceSSL must be defined');
   assert(options.trustProxy !== undefined,  'trustProxy must be defined');
-  assert(options.docs, 'options.docs must be given')
-
+  assert(options.docs, 'options.docs must be given');
 
   // Create application
   var app = express();
@@ -140,8 +139,8 @@ var app = function(options) {
 
   if (options.rootDocsRedirect) {
     let link = options.docs.documenter.getDocumentationUrl();
-    DOCS_HTML = "<html><body><a href="+link+">Refer to the documentation</a></body></html>"
-    app.get('/',function(req,res){
+    DOCS_HTML = "<html><body><a href="+link+">Refer to the documentation</a></body></html>";
+    app.get('/', function(req, res) {
       res.send(DOCS_HTML);
     });
   }

--- a/src/app.js
+++ b/src/app.js
@@ -135,7 +135,7 @@ var app = function(options) {
 
   if (options.rootDocsRedirect) {
     let link = options.docs.documenter.getDocumentationUrl();
-    DOCS_HTML = '<html><body><a href='+link+'>Refer to the documentation</a></body></html>';
+    DOCS_HTML = `<html><body><p>You're lost, here's the way out.</p><a href= ${link} >Refer to the documentation</a></body></html>`;
     app.get('/', function(req, res) {
       res.status(404).send(DOCS_HTML);
     });

--- a/src/app.js
+++ b/src/app.js
@@ -139,7 +139,7 @@ var app = function(options) {
 
   if (options.rootDocsRedirect) {
     let link = options.docs.documenter.getDocumentationUrl();
-    DOCS_HTML = "<html><body><a href="+link+">Refer to the documentation</a></body></html>";
+    DOCS_HTML = '<html><body><a href='+link+'>Refer to the documentation</a></body></html>';
     app.get('/', function(req, res) {
       res.send(DOCS_HTML);
     });

--- a/src/app.js
+++ b/src/app.js
@@ -62,6 +62,8 @@ var createServer = function() {
  *   trustProxy:            false,          // Trust the proxy that forwarded for SSL
  *   contentSecurityPolicy: true,           // Send CSP (default true!)
  *   robotsTxt:             true,           // Serve a disallow-all robots.txt
+ *   rootDocRedirect:       true,           // Indicator to redirect to a HTML with documentation link (default true!)
+ *   docs:                  'docs',         // Instance of taskcluster-lib-docs for accessing its methods
  * }
  *
  * Returns an express application with extra methods:
@@ -72,6 +74,7 @@ var app = function(options) {
   _.defaults(options, {
     contentSecurityPolicy: true,
     robotsTxt: true,
+    rootDocsRedirect: true,
   });
   assert(typeof options.port === 'number', 'Port must be a number');
   assert(options.env == 'development' ||
@@ -133,6 +136,8 @@ var app = function(options) {
     });
   }
 
+  // If rootDocsRedirect == true ,
+  // we redirect to a HTML page with documentation link
   if (options.rootDocsRedirect) {
     let link = options.docs.documenter.getDocumentationUrl();
     DOCS_HTML = `<html><body><p>You're lost, here's the way out.</p>

--- a/src/app.js
+++ b/src/app.js
@@ -78,7 +78,7 @@ var app = function(options) {
          options.env == 'production',       'env must be production or development');
   assert(options.forceSSL !== undefined,    'forceSSL must be defined');
   assert(options.trustProxy !== undefined,  'trustProxy must be defined');
-  assert(options.docs, 'options.docs must be given');
+  assert(!options.rootDocsRedirect || options.docs, 'options.docs must be given if rootDocsRedirect is specified');
 
   // Create application
   var app = express();
@@ -133,15 +133,11 @@ var app = function(options) {
     });
   }
 
-  if (options.docs == undefined) {
-    options.rootDocsRedirect = false;
-  }
-
   if (options.rootDocsRedirect) {
     let link = options.docs.documenter.getDocumentationUrl();
     DOCS_HTML = '<html><body><a href='+link+'>Refer to the documentation</a></body></html>';
     app.get('/', function(req, res) {
-      res.send(DOCS_HTML);
+      res.status(404).send(DOCS_HTML);
     });
   }
 

--- a/src/app.js
+++ b/src/app.js
@@ -78,6 +78,8 @@ var app = function(options) {
          options.env == 'production',       'env must be production or development');
   assert(options.forceSSL !== undefined,    'forceSSL must be defined');
   assert(options.trustProxy !== undefined,  'trustProxy must be defined');
+  assert(options.docs, 'options.docs must be given')
+
 
   // Create application
   var app = express();
@@ -129,6 +131,18 @@ var app = function(options) {
     app.use('/robots.txt', function(req, res) {
       res.header('Content-Type', 'text/plain');
       res.send('User-Agent: *\nDisallow: /\n');
+    });
+  }
+
+  if (options.docs == undefined) {
+    options.rootDocsRedirect = false;
+  }
+
+  if (options.rootDocsRedirect) {
+    let link = options.docs.documenter.getDocumentationUrl();
+    DOCS_HTML = "<html><body><a href="+link+">Refer to the documentation</a></body></html>"
+    app.get('/',function(req,res){
+      res.send(DOCS_HTML);
     });
   }
 

--- a/test/app_test.js
+++ b/test/app_test.js
@@ -9,13 +9,16 @@ suite('app', function() {
     var server;
 
     suiteSetup(async function() {
+
+      let fakeDocs = {documentationUrl: 'https://fake.documentation/url'};
       // Create a simple app
       var app = subject({
-        port:       1459,
-        env:        'development',
-        forceSSL:   false,
-        forceHSTS:  true,
-        trustProxy: false,
+        port:             1459,
+        env:              'development',
+        forceSSL:         false,
+        forceHSTS:        true,
+        trustProxy:       false,
+        docs:             fakeDocs,
       });
       assert(app, 'Should have an app');
 
@@ -45,6 +48,14 @@ suite('app', function() {
       assert.equal(res.text, 'User-Agent: *\nDisallow: /\n', 'Got the right text');
       assert.equal(res.headers['content-type'], 'text/plain; charset=utf-8');
     });
+
+    test('get /', async function() {
+      var res = await request
+        .get('http://localhost:1459/')
+        .ok(res => res.status < 500);
+      assert(res.status, 404, 'Got 404 status');
+      assert(res.text.includes('https://fake.documentation/url'));
+    }); 
 
     suiteTeardown(function() {
       return server.terminate();


### PR DESCRIPTION
Added two new options 'docs' and 'rootDocsRedirect' . If rootDocsRedirect is true, then a static HTML containing the link to the documentation is rendered.