### PR TITLE
Add 404 error handler to prevent Content-Security-Policy header being overwritten

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -26,6 +26,12 @@ var notifyLocalAppInParentProcess = function(port) {
 /** Create server from app */
 var createServer = function() {
   var that = this;
+
+  this.use(function(req, res, next) {
+    res.setHeader('Content-Type', 'application/json');
+    res.status(404).json({Message: 'Not found'});
+  });
+
   return new Promise(function(accept, reject) {
     // Launch HTTP server
     var server = http.createServer(that);

--- a/src/app.js
+++ b/src/app.js
@@ -27,6 +27,7 @@ var notifyLocalAppInParentProcess = function(port) {
 var createServer = function() {
   var that = this;
 
+  // 404 Error Handler
   this.use(function(req, res, next) {
     res.setHeader('Content-Type', 'application/json');
     res.status(404).json({Message: 'Not found'});


### PR DESCRIPTION
I add a 404 error handler within createServer, since this is called at the bottom of the stack. This returns a JSON error message (in keeping with the rest of the app) and also prevents the Content-Security-Policy headers from being overwritten by the default 404 error message.

More information and discussion of the bug that this fixes can be found [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1421330).