### PR TITLE
Bug 1488387 - Attach Request ID to all requests objects and http response headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taskcluster-lib-app",
-  "version": "10.0.0",
+  "version": "10.1.0",
   "author": "Jonas Finnemann Jensen <jopsen@gmail.com>",
   "description": "taskcluster-lib-app",
   "license": "MPL-2.0",
@@ -25,11 +25,13 @@
     "lodash": "4.17.4",
     "morgan": "^1.9.0",
     "morgan-debug": "^2.0.0",
-    "promise": "^8.0.1"
+    "promise": "^8.0.1",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "eslint": "^4.10.0",
     "eslint-config-taskcluster": "^3.0.0",
+    "is-uuid": "^1.0.2",
     "mocha": "4.0.1",
     "superagent": "3.8.0"
   },

--- a/src/app.js
+++ b/src/app.js
@@ -8,6 +8,7 @@ var http            = require('http');
 var sslify          = require('express-sslify');
 var hsts            = require('hsts');
 var csp             = require('content-security-policy');
+var uuidv4          = require('uuid/v4');
 
 /** Notify LocalApp if running under this */
 var notifyLocalAppInParentProcess = function(port) {
@@ -108,6 +109,14 @@ var app = async function(options) {
   app.disable('x-powered-by');
   app.use((req, res, next) => {
     res.setHeader('x-content-type-options', 'nosniff');
+    next();
+  });
+
+  // attach request-id to request object and response
+  app.use((req, res, next) => {
+    let reqId = req.headers['x-request-id'] || uuidv4();
+    req.requestId = reqId;
+    res.setHeader('x-for-request-id', reqId);
     next();
   });
 

--- a/test/app_test.js
+++ b/test/app_test.js
@@ -1,9 +1,11 @@
+var assert = require('assert');
+var path = require('path');
+var App = require('../');
+var request = require('superagent');
+var express = require('express');
+var isUUID = require('is-uuid');
+
 suite('app', function() {
-  var assert = require('assert');
-  var path = require('path');
-  var App = require('../');
-  var request = require('superagent');
-  var express = require('express');
 
   // Test app creation
   suite('app({port: 1459})', function() {
@@ -16,6 +18,12 @@ suite('app', function() {
           const router = express.Router();
           router.get('/test', function(req, res) {
             res.status(200).send('Okay this works');
+          });
+          router.get('/req-id', function(req, res) {
+            res.status(200).send(JSON.stringify({
+              header: req.headers['x-request-id'],
+              valueSet: req.requestId,
+            }));
           });
           app.use('/api/test/v1', router);
         },
@@ -41,6 +49,27 @@ suite('app', function() {
     test('hsts header', async function() {
       var res = await request.get('http://localhost:1459/api/test/v1/test');
       assert.equal(res.headers['strict-transport-security'], 'max-age=7776000000; includeSubDomains');
+    });
+
+    test('request ids', async function() {
+      var res = await request
+        .get('http://localhost:1459/api/test/v1/req-id')
+        .buffer();
+      var body = JSON.parse(res.text);
+      assert(isUUID.v4(res.headers['x-for-request-id']));
+      assert(!isUUID.v4(body.header));
+      assert(isUUID.v4(body.valueSet));
+    });
+
+    test('request ids (heroku)', async function() {
+      var res = await request
+        .get('http://localhost:1459/api/test/v1/req-id')
+        .set('X-Request-Id', 'TestingRequestId')
+        .buffer();
+      var body = JSON.parse(res.text);
+      assert.equal(res.headers['x-for-request-id'], 'TestingRequestId');
+      assert.equal(body.header, 'TestingRequestId');
+      assert.equal(body.valueSet, 'TestingRequestId');
     });
 
     test('/robots.txt', async function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,6 +706,10 @@ is-resolvable@^1.0.0:
   dependencies:
     tryit "^1.0.1"
 
+is-uuid@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-uuid/-/is-uuid-1.0.2.tgz#ad1898ddf154947c25c8e54966f48604e9caecc4"
+
 isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -1246,6 +1250,10 @@ util-deprecate@~1.0.1:
 utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
+
+uuid@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Implemented here because this needs to be an App-level middleware.  We can support other hosting than heroku either by configuring them to use x-request-id, or by looking up other places for the incoming request id as appropriate.